### PR TITLE
sha256 erzwingen

### DIFF
--- a/src/opendkim-manage
+++ b/src/opendkim-manage
@@ -1080,7 +1080,7 @@ class Manager(object):
                         " created")
                 if cmd.config.update_dns:
                     ns = DNS(cf)
-                    rcontent = "v=DKIM1; k=rsa; s=email; p=" + \
+                    rcontent = "v=DKIM1; k=rsa; h=sha256; p=" + \
                                self.raw_cert(pub_key)
                     ns.add_dkim_key(cmd.config.domain[0], selector, rcontent)
 


### PR DESCRIPTION
sha1 ist als Signatur-Algorithmus für DKIM seit Januar offiziell deprecated (https://tools.ietf.org/html/rfc8301)
Daher ist sinnvoll, auch im DNS an den Publickey ranzuschreiben "nur mit SHA256" zu verwenden.

"s=email" hingegen ist aus meiner Sicht überflüssig. Da ist nicht absehbar, dass es andere Werte geben wird und kann daher weggelassen werden.